### PR TITLE
BVTCK-32 Adding test case for traversable resolver and method validation...

### DIFF
--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/messageinterpolation/MessageInterpolationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/messageinterpolation/MessageInterpolationTest.java
@@ -260,6 +260,11 @@ public class MessageInterpolationTest extends Arquillian {
 		public Object getValidatedValue() {
 			return null;
 		}
+
+		@Override
+		public <T> T unwrap(Class<T> type) {
+			throw new RuntimeException( "ups" );
+		}
 	}
 
 	public class DummyEntity {

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/MethodValidationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/MethodValidationTest.java
@@ -86,8 +86,7 @@ public class MethodValidationTest extends Arquillian {
 		executableValidator = TestUtil.getValidatorUnderTest().forExecutables();
 	}
 
-	//fails due to https://hibernate.onjira.com/browse/HV-673
-	@Test(groups = Groups.FAILING_IN_RI)
+	@Test
 	@SpecAssertion(section = "4.6.2", id = "a")
 	public void methodParameterValidationTargetsParameterCrossParameterAndCascadedConstraints()
 			throws Exception {
@@ -133,8 +132,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 	}
 
-	//fails due to https://hibernate.onjira.com/browse/HV-673
-	@Test(groups = Groups.FAILING_IN_RI)
+	@Test
 	@SpecAssertion(section = "4.6.2", id = "a")
 	public void methodParameterValidationIncludesConstraintsFromSuperClass() throws Exception {
 		String methodName = "placeOrder";
@@ -179,8 +177,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 	}
 
-	//fails due to https://hibernate.onjira.com/browse/HV-673
-	@Test(groups = Groups.FAILING_IN_RI)
+	@Test
 	@SpecAssertion(section = "4.6.2", id = "a")
 	public void methodParameterValidationIncludesConstraintsFromImplementedInterface()
 			throws Exception {
@@ -226,8 +223,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 	}
 
-	//fails due to https://hibernate.onjira.com/browse/HV-673
-	@Test(groups = Groups.FAILING_IN_RI)
+	@Test
 	@SpecAssertion(section = "4.6.2", id = "a")
 	public void methodParameterValidationIsAppliedGroupWise() throws Exception {
 		String methodName = "placeOrder";
@@ -293,8 +289,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 	}
 
-	//fails due to https://hibernate.onjira.com/browse/HV-673
-	@Test(groups = Groups.FAILING_IN_RI)
+	@Test
 	@SpecAssertion(section = "4.6.2", id = "a")
 	public void methodParameterValidationPerformsGroupConversion() throws Exception {
 		String methodName = "placeOrder";
@@ -375,8 +370,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 	}
 
-	//fails due to https://hibernate.onjira.com/browse/HV-673
-	@Test(groups = Groups.FAILING_IN_RI)
+	@Test
 	@SpecAssertions({
 			@SpecAssertion(section = "4.6.2", id = "a"),
 			@SpecAssertion(section = "4.6.2", id = "d")
@@ -508,8 +502,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 	}
 
-	//fails due to https://hibernate.onjira.com/browse/HV-673
-	@Test(groups = Groups.FAILING_IN_RI)
+	@Test
 	@SpecAssertion(section = "4.6.2", id = "a")
 	public void constructorParameterValidationTargetsParameterCrossParameterAndCascadedConstraints()
 			throws Exception {
@@ -571,8 +564,7 @@ public class MethodValidationTest extends Arquillian {
 		assertCorrectNumberOfViolations( violations, 0 );
 	}
 
-	//fails due to https://hibernate.onjira.com/browse/HV-673
-	@Test(groups = Groups.FAILING_IN_RI)
+	@Test
 	@SpecAssertion(section = "4.6.2", id = "a")
 	public void constructorParameterValidationIsAppliedGroupWise() throws Exception {
 		String className = "OrderService";
@@ -634,8 +626,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 	}
 
-	//fails due to https://hibernate.onjira.com/browse/HV-673
-	@Test(groups = Groups.FAILING_IN_RI)
+	@Test
 	@SpecAssertion(section = "4.6.2", id = "a")
 	public void constructorParameterValidationPerformsGroupConversion() throws Exception {
 		String className = "OrderService";
@@ -710,8 +701,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 	}
 
-	//fails due to https://hibernate.onjira.com/browse/HV-673
-	@Test(groups = Groups.FAILING_IN_RI)
+	@Test
 	@SpecAssertions({
 			@SpecAssertion(section = "4.6.2", id = "a"),
 			@SpecAssertion(section = "4.6.2", id = "d")
@@ -1025,8 +1015,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 	}
 
-	//fails due to https://hibernate.onjira.com/browse/HV-673
-	@Test(groups = Groups.FAILING_IN_RI)
+	@Test
 	@SpecAssertion(section = "4.6.2", id = "b")
 	public void methodReturnValueValidationPerformsGroupConversion() throws Exception {
 		String methodName = "placeOrder";
@@ -1355,8 +1344,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 	}
 
-	//fails due to https://hibernate.onjira.com/browse/HV-673
-	@Test(groups = Groups.FAILING_IN_RI)
+	@Test
 	@SpecAssertion(section = "4.6.2", id = "b")
 	public void constructorReturnValueValidationPerformsGroupConversion() throws Exception {
 		String className = "OrderService";

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/traversableresolver/Call.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/traversableresolver/Call.java
@@ -1,0 +1,107 @@
+/*
+* JBoss, Home of Professional Open Source
+* Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual contributors
+* by the @authors tag. See the copyright.txt in the distribution for a
+* full listing of individual contributors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.hibernate.beanvalidation.tck.tests.traversableresolver;
+
+/**
+ * @author Hardy Ferentschik
+ */
+
+import java.lang.annotation.ElementType;
+import java.util.Arrays;
+
+/**
+ * Wrapper class for keeping track of the parameters for a single call to {@link SnifferTraversableResolver#isReachable}
+ * and {@link SnifferTraversableResolver#isCascadable}.
+ */
+final class Call {
+	private Object traversableObject;
+	private String traversableProperty;
+	private Class<?> rootBeanType;
+	private String[] nodeNamesToTraversableObject;
+	private ElementType elementType;
+
+	Call(Object traversableObject,
+		 String traversableProperty,
+		 Class<?> rootBeanType,
+		 ElementType elementType,
+		 String[] nodeNamesToTraversableObject) {
+		this.traversableObject = traversableObject;
+		this.traversableProperty = traversableProperty;
+		this.rootBeanType = rootBeanType;
+		this.nodeNamesToTraversableObject = nodeNamesToTraversableObject;
+		this.elementType = elementType;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( this == o ) {
+			return true;
+		}
+		if ( o == null || getClass() != o.getClass() ) {
+			return false;
+		}
+
+		Call call = (Call) o;
+
+		if ( elementType != call.elementType ) {
+			return false;
+		}
+		if ( !Arrays.equals( nodeNamesToTraversableObject, call.nodeNamesToTraversableObject ) ) {
+			return false;
+		}
+		if ( rootBeanType != null ? !rootBeanType.equals( call.rootBeanType ) : call.rootBeanType != null ) {
+			return false;
+		}
+		if ( traversableObject != null ? !traversableObject.equals( call.traversableObject ) : call.traversableObject != null ) {
+			return false;
+		}
+		if ( traversableProperty != null ? !traversableProperty.equals( call.traversableProperty ) : call.traversableProperty != null ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = traversableObject != null ? traversableObject.hashCode() : 0;
+		result = 31 * result + ( traversableProperty != null ? traversableProperty.hashCode() : 0 );
+		result = 31 * result + ( rootBeanType != null ? rootBeanType.hashCode() : 0 );
+		result = 31 * result + ( nodeNamesToTraversableObject != null ? Arrays.hashCode( nodeNamesToTraversableObject ) : 0 );
+		result = 31 * result + ( elementType != null ? elementType.hashCode() : 0 );
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		final StringBuilder sb = new StringBuilder();
+		sb.append( "Call" );
+		sb.append( "{traversableObject=" ).append( traversableObject );
+		sb.append( ", traversableProperty='" ).append( traversableProperty ).append( '\'' );
+		sb.append( ", rootBeanType=" ).append( rootBeanType );
+		sb.append( ", nodeNamesToTraversableObject=" )
+				.append(
+						nodeNamesToTraversableObject == null ? "null" : Arrays.asList( nodeNamesToTraversableObject )
+								.toString()
+				);
+		sb.append( ", elementType=" ).append( elementType );
+		sb.append( '}' );
+		return sb.toString();
+	}
+}
+
+

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/traversableresolver/Gentleman.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/traversableresolver/Gentleman.java
@@ -1,0 +1,39 @@
+/*
+* JBoss, Home of Professional Open Source
+* Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual contributors
+* by the @authors tag. See the copyright.txt in the distribution for a
+* full listing of individual contributors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.hibernate.beanvalidation.tck.tests.traversableresolver;
+
+import javax.validation.Valid;
+
+/**
+ * @author Hardy Ferentschik
+ */
+public class Gentleman {
+	private Suit suit;
+
+	public void wearSuit(@Valid Suit suit) {
+		this.suit = suit;
+	}
+
+	@Valid
+	public Suit undress() {
+		Suit tmpSuit = this.suit;
+		this.suit = null;
+		return tmpSuit;
+	}
+}
+
+

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/util/TestUtil.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/util/TestUtil.java
@@ -211,7 +211,6 @@ public final class TestUtil {
 	}
 
 	public static void assertDescriptorKinds(Path path, Kind... kinds) {
-
 		Iterator<Node> pathIterator = path.iterator();
 
 		for ( Kind kind : kinds ) {
@@ -223,7 +222,6 @@ public final class TestUtil {
 	}
 
 	public static void assertNodeNames(Path path, String... names) {
-
 		Iterator<Node> pathIterator = path.iterator();
 
 		for ( String name : names ) {
@@ -406,7 +404,6 @@ public final class TestUtil {
 	}
 
 	public static class PathImpl implements Path {
-
 		/**
 		 * Regular expression used to split a string path into its elements.
 		 *


### PR DESCRIPTION
.... Really should behave as in the bean validation setup

Updating test for traversable resolver to not make use of string representation of traversable path
