### PR TITLE
Adding missing class to web archive

### DIFF
--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateConstructorParametersTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateConstructorParametersTest.java
@@ -66,6 +66,7 @@ public class ValidateConstructorParametersTest extends AbstractTCKTest {
 				.withClass( OrderLine.class )
 				.withClass( User.class )
 				.withClass( StockItemRecord.class )
+                .withClass( ComplexStockItemRecord.class )
 				.withClass( ContainerElementsOrder.class )
 				.withClass( ProductCategory.class )
 				.build();


### PR DESCRIPTION
ValidateConstructorParametersTest.java is missing the new ComplexStockItemRecord.class in the web archive.