### PR TITLE
Make sure that there are no encoded symbols in the jar file paths

### DIFF
--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/AbstractTCKTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/AbstractTCKTest.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.beanvalidation.tck.tests;
 
+import java.net.URISyntaxException;
+
 import com.beust.jcommander.JCommander;
 import jakarta.validation.Validator;
 import jakarta.validation.executable.ExecutableValidator;
@@ -48,18 +50,9 @@ public abstract class AbstractTCKTest extends Arquillian {
 		// Thus we use the protection domain API to obtain the original jar and include it in the war.
 		// According to our security policy, the TCK has the permission to access the API even if
 		// the security manager is enabled.
-		webArchiveBuilder.withAdditionalJar( Assert.class.getProtectionDomain()
-				.getCodeSource()
-				.getLocation()
-				.getPath()
-		);
+		webArchiveBuilder.withAdditionalJar( jarPath( Assert.class ) );
 		// testng 6.14.3 has dependency on jcommander
-		webArchiveBuilder.withAdditionalJar( JCommander.class.getProtectionDomain()
-													 .getCodeSource()
-													 .getLocation()
-													 .getPath()
-		);
-
+		webArchiveBuilder.withAdditionalJar( jarPath( JCommander.class ) );
 
 		return webArchiveBuilder;
 	}
@@ -76,5 +69,18 @@ public abstract class AbstractTCKTest extends Arquillian {
 			executableValidator = getValidator().forExecutables();
 		}
 		return executableValidator;
+	}
+
+	private static String jarPath(Class<?> libraryClass) {
+		try {
+			return libraryClass.getProtectionDomain()
+					.getCodeSource()
+					.getLocation()
+					.toURI()
+					.getPath();
+		}
+		catch (URISyntaxException e) {
+			throw new IllegalStateException( "Cannot resolve jar path for " + libraryClass.getPackageName(), e );
+		}
 	}
 }


### PR DESCRIPTION
Hey @starksm64 ,

I was looking into problems running a TCK on CI after some unrelated upgrades, and noticed that using code source location can result in a path like:
```
file:/var/lib/jenkins/workspace/hibernate-validator_PR-1347%40tmp/maven-repository/org/assertj/assertj-core/3.8.0/assertj-core-3.8.0.jar
```
where `@` is encoded (`%40`) and which results in this file being not found. The suggested change to call `toURI` should address the encoding/decoding issue.