### PR TITLE
[#270] Make sure that ArchiveClassLoader "loads" service files / Move non-container-specific tests out of integration-only tests

### DIFF
--- a/standalone-container-adapter/src/main/java/org/hibernate/validator/tck/arquillian/ArchiveClassLoader.java
+++ b/standalone-container-adapter/src/main/java/org/hibernate/validator/tck/arquillian/ArchiveClassLoader.java
@@ -14,6 +14,10 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
 
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.Node;
@@ -65,6 +69,28 @@ public class ArchiveClassLoader extends URLClassLoader {
 		}
 		else {
 			return super.getResource( name );
+		}
+	}
+
+	@Override
+	public Enumeration<URL> getResources(String name) throws IOException {
+		Enumeration<URL> defaultResources = super.getResources(name);
+		if ( archive.get( archivePrefix + name ) != null ) {
+			try {
+				URL archiveResource = new URL(null, "archive:" + archive.getName() + "/" + name, new ArchiveURLStreamHandler());
+				List<URL> urls = new ArrayList<>();
+				urls.add(archiveResource);
+				while ( defaultResources.hasMoreElements() ) {
+					urls.add(defaultResources.nextElement());
+				}
+				return Collections.enumeration(urls);
+			}
+			catch (MalformedURLException e) {
+				throw new RuntimeException( "Could not create URL for archive: " + archive.getName() + " and resource " + name, e );
+			}
+		}
+		else {
+			return defaultResources;
 		}
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/bootstrap/customprovider/BootstrapCustomProviderDefinedInServiceFileTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/bootstrap/customprovider/BootstrapCustomProviderDefinedInServiceFileTest.java
@@ -17,7 +17,6 @@ import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
 import org.hibernate.beanvalidation.tck.common.TCKValidationProvider;
 import org.hibernate.beanvalidation.tck.common.TCKValidatorConfiguration;
 import org.hibernate.beanvalidation.tck.tests.AbstractTCKTest;
-import org.hibernate.beanvalidation.tck.util.IntegrationTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -28,7 +27,6 @@ import org.testng.annotations.Test;
 /**
  * @author Hardy Ferentschik
  */
-@IntegrationTest
 @SpecVersion(spec = "beanvalidation", version = "4.0.0")
 public class BootstrapCustomProviderDefinedInServiceFileTest extends AbstractTCKTest {
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/constraintdefinition/serviceloading/ServiceLoadedConstraintOrderTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/constraintdefinition/serviceloading/ServiceLoadedConstraintOrderTest.java
@@ -15,7 +15,6 @@ import java.util.Set;
 
 import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
 import org.hibernate.beanvalidation.tck.tests.AbstractTCKTest;
-import org.hibernate.beanvalidation.tck.util.IntegrationTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -32,7 +31,6 @@ import org.testng.annotations.Test;
  * @author Marko Bekhta
  */
 @SpecVersion(spec = "beanvalidation", version = "4.0.0")
-@IntegrationTest
 public class ServiceLoadedConstraintOrderTest extends AbstractTCKTest {
 
 	@Deployment

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/constraintdefinition/serviceloading/ServiceLoadedConstraintTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/constraintdefinition/serviceloading/ServiceLoadedConstraintTest.java
@@ -15,7 +15,6 @@ import java.util.Set;
 
 import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
 import org.hibernate.beanvalidation.tck.tests.AbstractTCKTest;
-import org.hibernate.beanvalidation.tck.util.IntegrationTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -32,7 +31,6 @@ import org.testng.annotations.Test;
  * @author Marko Bekhta
  */
 @SpecVersion(spec = "beanvalidation", version = "4.0.0")
-@IntegrationTest
 public class ServiceLoadedConstraintTest extends AbstractTCKTest {
 
 	@Deployment

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/declaration/ValueExtractorFromServiceLoaderTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/declaration/ValueExtractorFromServiceLoaderTest.java
@@ -19,7 +19,6 @@ import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
 import org.hibernate.beanvalidation.tck.tests.AbstractTCKTest;
 import org.hibernate.beanvalidation.tck.tests.valueextraction.declaration.model.Cinema;
 import org.hibernate.beanvalidation.tck.tests.valueextraction.declaration.model.Reference;
-import org.hibernate.beanvalidation.tck.util.IntegrationTest;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
@@ -30,7 +29,6 @@ import org.testng.annotations.Test;
  * @author Guillaume Smet
  */
 @SpecVersion(spec = "beanvalidation", version = "4.0.0")
-@IntegrationTest
 public class ValueExtractorFromServiceLoaderTest extends AbstractTCKTest {
 
 	@Deployment

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/declaration/ValueExtractorsPrecedenceTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/declaration/ValueExtractorsPrecedenceTest.java
@@ -23,7 +23,6 @@ import org.hibernate.beanvalidation.tck.tests.valueextraction.declaration.model.
 import org.hibernate.beanvalidation.tck.tests.valueextraction.declaration.model.Reference;
 import org.hibernate.beanvalidation.tck.tests.valueextraction.declaration.model.ReferenceValueExtractor2;
 import org.hibernate.beanvalidation.tck.tests.valueextraction.declaration.model.ReferenceValueExtractor3;
-import org.hibernate.beanvalidation.tck.util.IntegrationTest;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
@@ -34,7 +33,6 @@ import org.testng.annotations.Test;
  * @author Guillaume Smet
  */
 @SpecVersion(spec = "beanvalidation", version = "4.0.0")
-@IntegrationTest
 public class ValueExtractorsPrecedenceTest extends AbstractTCKTest {
 
 	@Deployment


### PR DESCRIPTION
* Fixes #270

Tests that remain as `@IntegrationTest` and hence run only in container mode are:

```
org.hibernate.beanvalidation.tck.tests.integration.cdi.defaultinjection.DefaultInjectionTest
org.hibernate.beanvalidation.tck.tests.integration.cdi.executable.ExecutableValidationTest
org.hibernate.beanvalidation.tck.tests.integration.cdi.executable.global.ExecutableValidationBasedOnGlobalConfigurationTest
org.hibernate.beanvalidation.tck.tests.integration.cdi.executable.globallydisabled.ExecutableValidationGloballyDisabledTest
org.hibernate.beanvalidation.tck.tests.integration.cdi.executable.priority.ValidationInterceptorPriorityTest
org.hibernate.beanvalidation.tck.tests.integration.cdi.executable.types.ExecutableTypesTest
org.hibernate.beanvalidation.tck.tests.integration.cdi.factory.ConstraintValidatorInjectionTest
org.hibernate.beanvalidation.tck.tests.integration.cdi.managedobjects.ManagedObjectsTest
org.hibernate.beanvalidation.tck.tests.integration.cdi.managedobjects.ManagedServiceLoaderValueExtractorsTest
org.hibernate.beanvalidation.tck.tests.integration.cdi.managedobjects.ManagedValueExtractorsTest
org.hibernate.beanvalidation.tck.tests.integration.cdi.managedobjects.ManagedXmlAndServiceLoaderValueExtractorsTest
org.hibernate.beanvalidation.tck.tests.integration.ee.cdi.ConstraintValidatorInjectionTest
org.hibernate.beanvalidation.tck.tests.integration.ee.DefaultInjectionTest
org.hibernate.beanvalidation.tck.tests.integration.ee.JndiRetrievalTest
```

which require container integration.